### PR TITLE
PivotalTracker::Task.update() fix

### DIFF
--- a/lib/pivotal-tracker/task.rb
+++ b/lib/pivotal-tracker/task.rb
@@ -42,6 +42,7 @@ module PivotalTracker
             xml.complete "#{complete}"
           }
         end
+        return builder.to_xml
       end
 
   end


### PR DESCRIPTION
When updating a task, I get an error from Nokogiri like this:
'add_child': Document already has a root node (RuntimeError)

It is because the Nokogiri::XML::Builder is being passed into the restclient put() instead of an xml string.
