### PR TITLE
PivotalTracker::Activity.all :occurred_since_date filter patch

### DIFF
--- a/lib/pivotal-tracker/activity.rb
+++ b/lib/pivotal-tracker/activity.rb
@@ -23,7 +23,8 @@ module PivotalTracker
           if options[:occurred_since]
             options_string << "occurred_since_date=\"#{options[:occurred_since].utc}\""
           elsif options[:occurred_since_date]
-            options_string << "occurred_since_date=\"#{options[:occurred_since_date]}\""
+            #NOTE currently forces UTC as the timezone
+            options_string << "occurred_since_date=#{URI.escape options[:occurred_since_date].strftime("%Y/%m/%d %H:%M:%S UTC")}"
           end
 
           return "?#{options_string.join('&')}"

--- a/spec/unit/pivotal-tracker/activity_spec.rb
+++ b/spec/unit/pivotal-tracker/activity_spec.rb
@@ -20,4 +20,13 @@ describe PivotalTracker::Activity do
     end
   end
 
+  context "with a specified occurred since date filter" do
+    it "should correctly url encode the occurred since date filter in the API call" do
+      PivotalTracker::Client.stub!(:connection).and_return connection = double("Client Connection")
+      connection.should_receive(:[]).with("/activities?limit=100&occurred_since_date=2010/07/29%2019:13:00%20UTC")
+        .and_return double("Connection", :get => '<blah></blah>')
+      PivotalTracker::Activity.all nil, :limit => 100, :occurred_since_date => DateTime.parse("2010/7/29 19:13:00 UTC")
+    end
+  end
+
 end


### PR DESCRIPTION
Hi,

I patched the encoding of the :occurred_since_date filter because it was blowing up with a bad URI error (I'm on ruby 1.9.2). I added a test, but I couldn't make it stylistically fit with the other tests (i.e. I used mocks).

If you don't like how I fixed it, I hope that you'll consider fixing it in your own way and updating the gem (which I find very simple and useful, thanks!).

Best,
Chris
