### PR TITLE
simple fix for the timezone

### DIFF
--- a/lib/pivotal-tracker/activity.rb
+++ b/lib/pivotal-tracker/activity.rb
@@ -23,8 +23,7 @@ module PivotalTracker
           if options[:occurred_since]
             options_string << "occurred_since_date=\"#{options[:occurred_since].utc}\""
           elsif options[:occurred_since_date]
-            #NOTE currently forces UTC as the timezone
-            options_string << "occurred_since_date=#{URI.escape options[:occurred_since_date].strftime("%Y/%m/%d %H:%M:%S UTC")}"
+            options_string << "occurred_since_date=#{URI.escape options[:occurred_since_date].strftime("%Y/%m/%d %H:%M:%S %Z")}"
           end
 
           return "?#{options_string.join('&')}"


### PR DESCRIPTION
I think the option :occurred_since will still be broken because of the escaped quotes, and un-escaped time string, but since I don't know what the behavior is supposed to be (as opposed to :occurred_since_date) I left it alone.
