### PR TITLE
Add support for the labels element on a project

### DIFF
--- a/lib/pivotal-tracker/project.rb
+++ b/lib/pivotal-tracker/project.rb
@@ -21,6 +21,7 @@ module PivotalTracker
     element :account, String
     element :week_start_day, String
     element :point_scale, String
+    element :labels, String
     element :week_start_day, String
     element :velocity_scheme, String
     element :iteration_length, Integer


### PR DESCRIPTION
Tracker's API returns the labels on a project, I just added the element to the project class.
