### PR TITLE
Unable to create Tasks

### DIFF
--- a/lib/pivotal-tracker/task.rb
+++ b/lib/pivotal-tracker/task.rb
@@ -17,6 +17,17 @@ module PivotalTracker
     element :position, Integer
     element :complete, Boolean
     element :created_at, DateTime
+    has_one :story, Story
+
+    def initialize(attributes={})
+      if attributes[:owner]
+        self.story = attributes.delete(:owner)
+        self.project_id = self.story.project_id
+        self.story_id = self.story.id
+      end
+
+      update_attributes(attributes)
+    end
 
     def create
       response = Client.connection["/projects/#{project_id}/stories/#{story_id}/tasks"].post(self.to_xml, :content_type => 'application/xml')
@@ -45,6 +56,11 @@ module PivotalTracker
         return builder.to_xml
       end
 
+      def update_attributes(attrs)
+        attrs.each do |key, value|
+          self.send("#{key}=", value.is_a?(Array) ? value.join(',') : value )
+        end
+      end
   end
 
   class Task


### PR DESCRIPTION
Hey there, and thanks for the Gem! I just ran into an issue whereby I couldn't create tasks:

```
 002:0 > s = PivotalTracker::Project.find(PROJECT_ID).stories.all.first
 #=> #<PivotalTracker::Story:0xXXX @id=XXX, @url="http://www.pivotaltracker.com/story/show/XXX", @created_at=Thu, 01 Dec 2011 05:48:22 -0600, @accepted_at=nil, @project_id=XXX, @name="Test Story2", @description="Lorem Ipsum", @story_type="feature", @estimate=2, @current_state="unstarted", @requested_by="Ryan Long", @owned_by=nil, @labels="oeo,oeu", @jira_id=nil, @jira_url=nil, @other_id=nil, @integration_id=nil, @deadline=nil, @attachments=[]>
 003:0 > s.tasks.create({ :create => :oe })
ArgumentError: wrong number of arguments(1 for 0)
        from /home/ryan/Projects/pivotal-tracker-gem/lib/pivotal-tracker/proxy.rb:36:in `initialize'
        from /home/ryan/Projects/pivotal-tracker-gem/lib/pivotal-tracker/proxy.rb:36:in `new'
        from /home/ryan/Projects/pivotal-tracker-gem/lib/pivotal-tracker/proxy.rb:36:in `create'
        from (irb):3
        from /home/ryan/.rvm/rubies/ruby-1.9.3-p0/bin/irb:16:in `<main>'
 004:0 > s.tasks.create( "o" )
NoMethodError: undefined method `merge' for "o":String
        from /home/ryan/Projects/pivotal-tracker-gem/lib/pivotal-tracker/proxy.rb:36:in `create'
        from (irb):4
        from /home/ryan/.rvm/rubies/ruby-1.9.3-p0/bin/irb:16:in `<main>'
 005:0 > s.tasks.create( description: "Test" )
ArgumentError: wrong number of arguments(1 for 0)
        from /home/ryan/Projects/pivotal-tracker-gem/lib/pivotal-tracker/proxy.rb:36:in `initialize'
        from /home/ryan/Projects/pivotal-tracker-gem/lib/pivotal-tracker/proxy.rb:36:in `new'
        from /home/ryan/Projects/pivotal-tracker-gem/lib/pivotal-tracker/proxy.rb:36:in `create'
        from (irb):5
        from /home/ryan/.rvm/rubies/ruby-1.9.3-p0/bin/irb:16:in `<main>'
 006:0 > s.tasks.create()
ArgumentError: wrong number of arguments(0 for 1)
        from /home/ryan/Projects/pivotal-tracker-gem/lib/pivotal-tracker/proxy.rb:36:in `initialize'
        from /home/ryan/Projects/pivotal-tracker-gem/lib/pivotal-tracker/proxy.rb:36:in `new'
        from /home/ryan/Projects/pivotal-tracker-gem/lib/pivotal-tracker/proxy.rb:36:in `create'
        from (irb):5
        from /home/ryan/.rvm/rubies/ruby-1.9.3-p0/bin/irb:16:in `<main>'
```

An odd behavior... was a bit hard to track it down, but I discovered that copying the `initializer` from `Note` 
into `Task` fixed the problem. I honestly don't understand what's happening, here, with the Proxy and all that ActiveResource is doing; but, this solved the problem for me. I would guess the initializer was just forgotten in the case?

FTR: This problem _was_ occurring before I cloned it and ran the code from my local FS, which would have been the current release version of the gem.
