### PR TITLE
Add ability to call PivotalTracker::Project.create

### DIFF
--- a/spec/fixtures/stale_fish.yml
+++ b/spec/fixtures/stale_fish.yml
@@ -14,6 +14,13 @@
       request_type: GET
       update_method: StaleFishFixtures.update_projects_fixture
       last_updated_at: 2010-07-29T20:15:09+01:00
+  - create_projects:
+      file: 'projects.xml'
+      update_interval: 2.weeks
+      check_against: http://www.pivotaltracker.com/services/v3/projects
+      request_type: POST
+      update_method: StaleFishFixtures.update_projects_fixture
+      last_updated_at: 2010-07-29T13:15:09-06:00
   - tasks:
       file: 'tasks.xml'
       update_interval: 2.weeks

--- a/spec/unit/pivotal-tracker/project_spec.rb
+++ b/spec/unit/pivotal-tracker/project_spec.rb
@@ -52,4 +52,38 @@ describe PivotalTracker::Project do
       @project.respond_to?(:memberships).should be_true
     end
   end
+
+  context ".create" do
+    before do
+      @project = PivotalTracker::Project.new(:name => 'Pivotal Tracker API Gem')
+    end
+
+    it "should return the created project" do
+      @project.create
+      @project.should be_a(PivotalTracker::Project)
+      @project.name.should == 'Pivotal Tracker API Gem'
+    end
+
+    context "on failure" do
+      before do
+        FakeWeb.register_uri(:post, "http://www.pivotaltracker.com/services/v3/projects",
+                             :body   => %{<?xml version="1.0" encoding="UTF-8"?>
+             <errors>
+               <error>error#1 message</error>
+               <error>error#2 message</error>
+             </errors>%},
+                             :status => "422")
+      end
+
+      it "should not raise an exception" do
+        expect { @project.create }.to_not raise_error(Exception)
+      end
+
+      it "should report errors encountered" do
+        @project.create
+        @project.errors.messages.should =~ ["error#1 message", "error#2 message"]
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Add an API call to crate new Pivotal Tracker Projects.

Usage:
  options = {
    :name => 'My new project',
    :iteration_length => '4',
    :point_scale => "1,2,3,4,5"
  }
  p = PivotalTracker::Project.new(options)
  p.create

Name is required, iteration_length and point_scale
are optional
