### PR TITLE
Found a small bug in the way that tasks are associated with stories

### DIFF
--- a/lib/pivotal-tracker/task.rb
+++ b/lib/pivotal-tracker/task.rb
@@ -17,6 +17,7 @@ module PivotalTracker
     element :position, Integer
     element :complete, Boolean
     element :created_at, DateTime
+    has_one :story, Story
 
     def initialize(attributes={})
       if attributes[:owner]

--- a/spec/fixtures/stale_fish.yml
+++ b/spec/fixtures/stale_fish.yml
@@ -28,6 +28,13 @@
       request_type: GET
       update_method: StaleFishFixtures.update_tasks_fixture
       last_updated_at: 2010-07-29T20:15:10+01:00
+  - create_tasks:
+      file: 'tasks.xml'
+      update_interval: 2.weeks
+      check_against: http://www.pivotaltracker.com/services/v3/projects/102622/stories/4459994/tasks
+      request_type: POST
+      update_method: StaleFishFixtures.update_tasks_fixture
+      last_updated_at: 2010-07-29T20:15:10+01:00
   - project:
       file: 'project.xml'
       update_interval: 2.weeks

--- a/spec/pivotal-tracker/task_spec.rb
+++ b/spec/pivotal-tracker/task_spec.rb
@@ -18,4 +18,11 @@ describe PivotalTracker::Task do
       @story.tasks.find(468113).should be_a(PivotalTracker::Task)
     end
   end
+
+  context ".create" do
+    it "should return the created task" do
+      @story.tasks.create(:description => 'Test task')
+    end
+  end
+    
 end


### PR DESCRIPTION
The following code:

```
  PivotalTracker::Client.token = "xxxxxx"
  project = PivotalTracker::Project.all.find{ |i| i.name == 'blah' }
  story = project.stories.create( :name => self.title, :story_type => 'bug' )
  story.notes.create(:text => "my text" )
  self.features.each do |feature|
    story.tasks.create( :description => feature.text )
  end
```

Produced an error of: NoMethodError (undefined method `story=' for #PivotalTracker::Task:0x007fcdfba27440)

I have repaired this problem in Task.rb and added a spec for the problem.  Could you please pull the request and push a new version of the gem?  Thanks!
