### PR TITLE
Let Task#update take a Hash of attributes

### DIFF
--- a/lib/pivotal-tracker/task.rb
+++ b/lib/pivotal-tracker/task.rb
@@ -25,16 +25,17 @@ module PivotalTracker
         self.project_id = self.story.project_id
         self.story_id = self.story.id
       end
-      
+
       update_attributes(attributes)
     end
-    
+
     def create
       response = Client.connection["/projects/#{project_id}/stories/#{story_id}/tasks"].post(self.to_xml, :content_type => 'application/xml')
       return Task.parse(response)
     end
 
-    def update
+    def update(attr = {})
+      update_attributes(attr)
       response = Client.connection["/projects/#{project_id}/stories/#{story_id}/tasks/#{id}"].put(self.to_xml, :content_type => 'application/xml')
       return Task.parse(response)
     end

--- a/spec/fixtures/stale_fish.yml
+++ b/spec/fixtures/stale_fish.yml
@@ -28,6 +28,12 @@
       request_type: GET
       update_method: StaleFishFixtures.update_tasks_fixture
       last_updated_at: 2010-07-29T20:15:10+01:00
+  - update_tasks:
+      file: 'update_tasks.xml'
+      update_interval: 2.weeks
+      check_against: http://www.pivotaltracker.com/services/v3/projects/102622/stories/4459994/tasks/468113
+      request_type: PUT
+      update_method: StaleFishFixtures.update_tasks_fixture
   - create_tasks:
       file: 'tasks.xml'
       update_interval: 2.weeks

--- a/spec/fixtures/update_tasks.xml
+++ b/spec/fixtures/update_tasks.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<task>
+  <id type="integer">468113</id>
+  <description>Test task</description>
+  <position>1</position>
+  <complete>false</complete>
+  <created_at type="datetime">2010/07/27 21:51:28 UTC</created_at>
+</task>

--- a/spec/pivotal-tracker/task_spec.rb
+++ b/spec/pivotal-tracker/task_spec.rb
@@ -24,5 +24,10 @@ describe PivotalTracker::Task do
       @story.tasks.create(:description => 'Test task')
     end
   end
-    
+
+  context '.update' do
+    it "should return the updated task" do
+      @story.tasks.find(468113).update(:description => 'Test task').description.should == 'Test task'
+    end
+  end
 end


### PR DESCRIPTION
This allows you to update a task, for example to mark it as done.
Before, when you would try:

``` ruby
@story.tasks.find(123).update :complete => false
```

...you would get an `ArgumentError` since `Task#update` did not take any
arguments. When you tried:

``` ruby
task = @story.tasks.find(123)
task.complete = false
task.update
```

You would _still_ get an `ArgumentError` since the internal validations
engine would try to call `Task#update` with a Hash of attributes, like it
does elsewhere.

Now, calling `Task#update` will first use `Task#update_attributes` to set
any new attributes and then make the update request.
