### PR TITLE
Adds PivotalTracker::Iteration#team_strength

### DIFF
--- a/lib/pivotal-tracker/iteration.rb
+++ b/lib/pivotal-tracker/iteration.rb
@@ -33,6 +33,7 @@ module PivotalTracker
     element :number, Integer
     element :start, DateTime
     element :finish, DateTime
+    element :team_strength, Float
     has_many :stories, Story
 
   end

--- a/spec/fixtures/iterations_all.xml
+++ b/spec/fixtures/iterations_all.xml
@@ -5,6 +5,7 @@
     <number type="integer">1</number>
     <start type="datetime">2010/07/12 05:00:00 UTC</start>
     <finish type="datetime">2010/07/19 05:00:00 UTC</finish>
+	<team_strength type="float">1</team_strength>
     <stories type="array">
       <story>
         <id type="integer">4460116</id>
@@ -27,6 +28,7 @@
     <number type="integer">2</number>
     <start type="datetime">2010/07/19 05:00:00 UTC</start>
     <finish type="datetime">2010/07/26 05:00:00 UTC</finish>
+	<team_strength type="float">1</team_strength>
     <stories type="array">
     </stories>
   </iteration>
@@ -35,6 +37,7 @@
     <number type="integer">3</number>
     <start type="datetime">2010/07/26 05:00:00 UTC</start>
     <finish type="datetime">2010/08/02 05:00:00 UTC</finish>
+	<team_strength type="float">1</team_strength>
     <stories type="array">
       <story>
         <id type="integer">4459994</id>
@@ -79,6 +82,7 @@
     <number type="integer">4</number>
     <start type="datetime">2010/08/02 05:00:00 UTC</start>
     <finish type="datetime">2010/08/09 05:00:00 UTC</finish>
+	<team_strength type="float">1</team_strength>
     <stories type="array">
       <story>
         <id type="integer">4460038</id>
@@ -132,6 +136,7 @@
     <number type="integer">5</number>
     <start type="datetime">2010/08/09 05:00:00 UTC</start>
     <finish type="datetime">2010/08/16 05:00:00 UTC</finish>
+	<team_strength type="float">1</team_strength>
     <stories type="array">
       <story>
         <id type="integer">4460598</id>
@@ -171,6 +176,7 @@
     <number type="integer">6</number>
     <start type="datetime">2010/08/16 05:00:00 UTC</start>
     <finish type="datetime">2010/08/23 05:00:00 UTC</finish>
+	<team_strength type="float">1</team_strength>
     <stories type="array">
       <story>
         <id type="integer">4473735</id>

--- a/spec/fixtures/iterations_backlog.xml
+++ b/spec/fixtures/iterations_backlog.xml
@@ -5,6 +5,7 @@
     <number type="integer">4</number>
     <start type="datetime">2010/08/02 05:00:00 UTC</start>
     <finish type="datetime">2010/08/09 05:00:00 UTC</finish>
+	<team_strength type="float">1</team_strength>
     <stories type="array">
       <story>
         <id type="integer">4460038</id>
@@ -58,6 +59,7 @@
     <number type="integer">5</number>
     <start type="datetime">2010/08/09 05:00:00 UTC</start>
     <finish type="datetime">2010/08/16 05:00:00 UTC</finish>
+	<team_strength type="float">1</team_strength>
     <stories type="array">
       <story>
         <id type="integer">4460598</id>
@@ -97,6 +99,7 @@
     <number type="integer">6</number>
     <start type="datetime">2010/08/16 05:00:00 UTC</start>
     <finish type="datetime">2010/08/23 05:00:00 UTC</finish>
+	<team_strength type="float">1</team_strength>
     <stories type="array">
       <story>
         <id type="integer">4473735</id>

--- a/spec/fixtures/iterations_current.xml
+++ b/spec/fixtures/iterations_current.xml
@@ -5,6 +5,7 @@
     <number type="integer">3</number>
     <start type="datetime">2010/07/26 05:00:00 UTC</start>
     <finish type="datetime">2010/08/02 05:00:00 UTC</finish>
+	<team_strength type="float">0.75</team_strength>
     <stories type="array">
       <story>
         <id type="integer">4459994</id>

--- a/spec/fixtures/iterations_current_backlog.xml
+++ b/spec/fixtures/iterations_current_backlog.xml
@@ -5,6 +5,7 @@
     <number type="integer">3</number>
     <start type="datetime">2010/07/26 05:00:00 UTC</start>
     <finish type="datetime">2010/08/02 05:00:00 UTC</finish>
+	<team_strength type="float">1</team_strength>
     <stories type="array">
       <story>
         <id type="integer">4459994</id>
@@ -49,6 +50,7 @@
     <number type="integer">4</number>
     <start type="datetime">2010/08/02 05:00:00 UTC</start>
     <finish type="datetime">2010/08/09 05:00:00 UTC</finish>
+	<team_strength type="float">1</team_strength>
     <stories type="array">
       <story>
         <id type="integer">4460038</id>
@@ -102,6 +104,7 @@
     <number type="integer">5</number>
     <start type="datetime">2010/08/09 05:00:00 UTC</start>
     <finish type="datetime">2010/08/16 05:00:00 UTC</finish>
+	<team_strength type="float">1</team_strength>
     <stories type="array">
       <story>
         <id type="integer">4460598</id>
@@ -141,6 +144,7 @@
     <number type="integer">6</number>
     <start type="datetime">2010/08/16 05:00:00 UTC</start>
     <finish type="datetime">2010/08/23 05:00:00 UTC</finish>
+	<team_strength type="float">1</team_strength>
     <stories type="array">
       <story>
         <id type="integer">4473735</id>

--- a/spec/fixtures/iterations_done.xml
+++ b/spec/fixtures/iterations_done.xml
@@ -5,6 +5,7 @@
     <number type="integer">1</number>
     <start type="datetime">2010/07/12 05:00:00 UTC</start>
     <finish type="datetime">2010/07/19 05:00:00 UTC</finish>
+	<team_strength type="float">1</team_strength>
     <stories type="array">
       <story>
         <id type="integer">4460116</id>

--- a/spec/pivotal-tracker/iteration_spec.rb
+++ b/spec/pivotal-tracker/iteration_spec.rb
@@ -60,6 +60,17 @@ describe PivotalTracker::Iteration do
     end
   end
   
+  describe ".team_strength" do
+    before do
+      @iteration = PivotalTracker::Iteration.current(@project)
+    end
+    
+    it "should return a Float" do
+      @iteration.should respond_to(:team_strength)
+      @iteration.team_strength.should be_a(Float)
+    end
+  end
+    
 
 end
 


### PR DESCRIPTION
Each Iteration has a team_strength property that can be used to manage velocity. This exposes the iteration's set velocity from the API.
