### PR TITLE
added external_id so integration_id works

### DIFF
--- a/lib/pivotal-tracker/story.rb
+++ b/lib/pivotal-tracker/story.rb
@@ -41,6 +41,7 @@ module PivotalTracker
     element :jira_url, String
     element :other_id, Integer
     element :integration_id, Integer
+    element :external_id, Integer
     element :deadline, DateTime # Only available for Release stories
 
     has_many :attachments, Attachment, :tag => 'attachments', :xpath => '//attachments'
@@ -132,6 +133,7 @@ module PivotalTracker
             # xml.jira_url "#{jira_url}"
             xml.other_id "#{other_id}" if other_id
             xml.integration_id "#{integration_id}" if integration_id
+            xml.external_id "#{external_id}" if external_id
             xml.created_at DateTime.parse(created_at.to_s).to_s if created_at
             xml.accepted_at DateTime.parse(accepted_at.to_s).to_s if accepted_at
             xml.deadline DateTime.parse(deadline.to_s).to_s if deadline

--- a/spec/pivotal-tracker/story_spec.rb
+++ b/spec/pivotal-tracker/story_spec.rb
@@ -197,6 +197,14 @@ describe PivotalTracker::Story do
         story_for(:other_id => 1000).keys.should_not include("integration_id")
       end
 
+      it "should include external_id" do
+        story_for(:external_id => 1000)["external_id"].should == '1000'
+      end
+
+      it "should not include external_id if it doesn't exist" do
+        story_for(:other_id => 1000).keys.should_not include("external_id")
+      end
+
       it "should not include other_id if it doesn't exist" do
         story_for(:project_id => 1000).keys.should_not include("other_id")
       end


### PR DESCRIPTION
Whenever I tried to use the `integration_id` field for a story, Pivotal Tracker kept telling me I needed to set its `external_id` too:

> Both the external_id and integration need to be set, but external_id is blank.

That's all I added. Coverage in tests present too.