### PR TITLE
Add support for "deliver all stories" API

### DIFF
--- a/lib/pivotal-tracker/project.rb
+++ b/lib/pivotal-tracker/project.rb
@@ -68,6 +68,11 @@ module PivotalTracker
       end
     end
 
+    def deliver_all_finished
+      response = Client.connection["/projects/#{self.id}/stories/deliver_all_finished"].put ""
+      Story.parse(response)
+    end
+
     protected
 
       def to_xml

--- a/spec/fixtures/deliver_all_finished.xml
+++ b/spec/fixtures/deliver_all_finished.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<stories type="array" count="1" limit="20" total="1">
+  <story>
+    <id type="integer">4460116</id>
+    <project_id type="integer">102622</project_id>
+    <story_type>feature</story_type>
+    <url>http://www.pivotaltracker.com/story/show/4460116</url>
+    <estimate type="integer">0</estimate>
+    <current_state>delivered</current_state>
+    <description>This is a story that's finished.</description>
+    <name>Old, accepted story</name>
+    <requested_by>Jon Mischo</requested_by>
+    <created_at type="datetime">2010/07/27 21:58:28 UTC</created_at>
+    <updated_at type="datetime">2010/07/27 22:21:17 UTC</updated_at>
+    <accepted_at type="datetime">2010/07/18 17:00:00 UTC</accepted_at>
+  </story>
+</stories>

--- a/spec/fixtures/stale_fish.yml
+++ b/spec/fixtures/stale_fish.yml
@@ -165,3 +165,9 @@
       check_against: http://www.pivotaltracker.com/services/v3/projects/102622/stories?filter=story_type%3Afeature
       request_type: GET
       last_updated_at: 
+  - deliver_all_finished:
+      file: 'deliver_all_finished.xml'
+      update_interval: nil
+      check_against: http://www.pivotaltracker.com/services/v3/projects/102622/stories/deliver_all_finished
+      request_type: PUT
+      last_updated_at: 

--- a/spec/pivotal-tracker/project_spec.rb
+++ b/spec/pivotal-tracker/project_spec.rb
@@ -95,4 +95,30 @@ describe PivotalTracker::Project do
     end
   end
 
+  context ".deliver_all_finished" do
+    before do
+      @project = PivotalTracker::Project.find(102622)
+    end
+
+    it "should deliver and return stories that were delivered" do
+      stories = @project.deliver_all_finished
+      stories.should be_a(Array)
+      stories.first.should be_a(PivotalTracker::Story)
+      stories.count.should == 1
+    end
+
+    context "with no stories set to finished" do
+      before do
+        FakeWeb.register_uri(:put, "#{PivotalTracker::Client.api_url}/projects/102622/stories/deliver_all_finished", 
+                             :body => %{<?xml version="1.0" encoding="UTF-8"?>
+<stories type="array"/>}, :status => "200")
+      end
+      
+      it "should return empty" do
+        @project.deliver_all_finished.count.should == 0
+      end
+    end
+  end
+
+
 end


### PR DESCRIPTION
Adds support for the deliver all finished stories API. (API doc: https://www.pivotaltracker.com/help/api?version=v3#deliver_all_finished)
