### PR TITLE
Cleanup dependencies in the gemspec.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,13 +5,13 @@ group :runtime do
   gem 'nokogiri-happymapper', '>= 0.5.4', :require => 'happymapper'
   gem 'builder'
   gem 'nokogiri', '>= 1.5.5'
-  gem 'crack'
 end
 
-group :test do
+group :development do
   gem 'rspec'
   gem 'rake'
   gem 'jeweler'
   gem 'stale_fish', '~> 1.3.2'
   gem 'autotest'
+  gem 'crack'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -14,15 +14,7 @@ begin
     gem.homepage = "http://github.com/jsmestad/pivotal-tracker"
     gem.authors = ["Justin Smestad", "Josh Nichols", "Terence Lee"]
 
-    gem.add_dependency 'rest-client', '~> 1.6.0'
-    gem.add_dependency 'happymapper', '>= 0.3.2'
-    gem.add_dependency 'builder'
-    gem.add_dependency 'nokogiri', '>= 1.4.3'
-
-    gem.add_development_dependency 'rspec'
-    gem.add_development_dependency 'bundler', '~> 1.0.12'
-    gem.add_development_dependency 'jeweler'
-    gem.add_development_dependency 'stale_fish', '~> 1.3.0'
+    # dependencies defined in Gemfile
   end
   Jeweler::GemcutterTasks.new
 rescue LoadError

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 require 'bundler'
 require 'fileutils'
 
-Bundler.require(:default, :runtime, :test)
+Bundler.require(:default, :runtime, :development)
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 


### PR DESCRIPTION
After adding this gem to a project, I noticed some weirdness around its dependencies:
- It depends on both nokogiri-happymapper and happymapper, but does not appear to use the latter. This has the unfortunate side effect of also making downstream projects pull in an build nokogiri and libxml-ruby.
- It lists crack as a runtime dependency, when it is only used in the project's own tests.
- It lists multiple versions of nokogiri.

This pull request cleans up the gemspec to deal with these issues. I am not familiar with jeweler at all, so I used their Rakefile and Gemfile as guides and could have messed something up.

This is what the dependency portion of the gemspec look like in current release (1.5.10):

```
      s.add_runtime_dependency(%q<rest-client>, ["~> 1.6.0"])
      s.add_runtime_dependency(%q<nokogiri-happymapper>, [">= 0.5.4"])
      s.add_runtime_dependency(%q<builder>, [">= 0"])
      s.add_runtime_dependency(%q<nokogiri>, [">= 1.5.5"])
      s.add_runtime_dependency(%q<crack>, [">= 0"])
      s.add_runtime_dependency(%q<rest-client>, ["~> 1.6.0"])
      s.add_runtime_dependency(%q<happymapper>, [">= 0.3.2"])
      s.add_runtime_dependency(%q<builder>, [">= 0"])
      s.add_runtime_dependency(%q<nokogiri>, [">= 1.4.3"])
      s.add_development_dependency(%q<rspec>, [">= 0"])
      s.add_development_dependency(%q<bundler>, ["~> 1.0.12"])
      s.add_development_dependency(%q<jeweler>, [">= 0"])
      s.add_development_dependency(%q<stale_fish>, ["~> 1.3.0"])
```

This is what the dependencies look like with this patch applied:

```
      s.add_runtime_dependency(%q<rest-client>, ["~> 1.6.0"])
      s.add_runtime_dependency(%q<nokogiri-happymapper>, [">= 0.5.4"])
      s.add_runtime_dependency(%q<builder>, [">= 0"])
      s.add_runtime_dependency(%q<nokogiri>, [">= 1.5.5"])
      s.add_development_dependency(%q<rspec>, [">= 0"])
      s.add_development_dependency(%q<rake>, [">= 0"])
      s.add_development_dependency(%q<jeweler>, [">= 0"])
      s.add_development_dependency(%q<stale_fish>, ["~> 1.3.2"])
      s.add_development_dependency(%q<autotest>, [">= 0"])
      s.add_development_dependency(%q<crack>, [">= 0"])
```
