### PR TITLE
Fixes Issue #79 - no date returned on stories attached to activities

### DIFF
--- a/lib/pivotal-tracker/activity.rb
+++ b/lib/pivotal-tracker/activity.rb
@@ -39,7 +39,7 @@ module PivotalTracker
     element :project_id, Integer
     element :description, String
 
-    has_many :stories, Story
+    has_many :stories, Story, :tag => "story"
 
   end
 end


### PR DESCRIPTION
The issue referenced seems to be due to an error in XML parsing in nokogiri-happymapper. The attached change is how I fixed it-- I'm not sure if this is a good way to fix it but it works.
