### PR TITLE
Related to Issue #79 -- returning iterations with nil stories

### DIFF
--- a/lib/pivotal-tracker/iteration.rb
+++ b/lib/pivotal-tracker/iteration.rb
@@ -34,7 +34,7 @@ module PivotalTracker
     element :start, DateTime
     element :finish, DateTime
     element :team_strength, Float
-    has_many :stories, Story
+    has_many :stories, Story, :tag => 'story'
 
   end
 end


### PR DESCRIPTION
This fix is related to Issue #79, where asking for iterations returned one story per iteration with nil properties and a whole bunch of attachments. This solution is the same as what @hannahhoward used in pull request #82.
