### PR TITLE
Added the ability to pass a file like object to upload_attachment, in ad...

### DIFF
--- a/lib/pivotal-tracker/story.rb
+++ b/lib/pivotal-tracker/story.rb
@@ -85,8 +85,9 @@ module PivotalTracker
       @tasks ||= Proxy.new(self, Task)
     end
 
-    def upload_attachment(filename)
-      Attachment.parse(Client.connection["/projects/#{project_id}/stories/#{id}/attachments"].post(:Filedata => File.new(filename)))
+    def upload_attachment(file)
+      file = File.new(file) if file.is_a?(String)
+      Attachment.parse(Client.connection["/projects/#{project_id}/stories/#{id}/attachments"].post(:Filedata => file))
     end
 
     def move_to_project(new_project)

--- a/spec/pivotal-tracker/attachment_spec.rb
+++ b/spec/pivotal-tracker/attachment_spec.rb
@@ -58,5 +58,14 @@ describe PivotalTracker::Attachment do
       resource.should be_a(PivotalTracker::Attachment)
       resource.status.should == 'Pending'
     end
+
+    it "should accept a file like object" do
+      FakeWeb.allow_net_connect = true
+      file = File.new(File.dirname(__FILE__) + '/../../LICENSE')
+      resource = @target_story.upload_attachment(file)
+      FakeWeb.allow_net_connect = @orig_net_lock
+      resource.should be_a(PivotalTracker::Attachment)
+      resource.status.should == 'Pending'
+    end
   end
 end


### PR DESCRIPTION
...dition to a file path.

This allows passing in an ActionDispatch::Http::UploadedFile, or any other file like object, which RestClient takes care of uploading.
