### PR TITLE
Update ZenTest version to fix errors during bundle install

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    ZenTest (4.9.3)
+    ZenTest (4.10.1)
     activesupport (3.2.9)
       i18n (~> 0.6)
       multi_json (~> 1.0)


### PR DESCRIPTION
:information_desk_person: The version of `ZenTest` listed in `Gemfile.lock` is incompatible with the current version of RubyGems and causes the `bundle install` command to fail. This change updates the version of `ZenTest` to fix this issue.