### PR TITLE
Update rest-client to 1.7.2 to avoid SSLv3 errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'http://rubygems.org'
 
 group :runtime do
-  gem 'rest-client', '~> 1.6.0'
+  gem 'rest-client', '>= 1.7.2'
   gem 'nokogiri-happymapper', '>= 0.5.4', :require => 'happymapper'
   gem 'builder'
   gem 'nokogiri', '>= 1.5.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,16 +19,18 @@ GEM
       rake
       rdoc
     json (1.7.5)
-    mime-types (1.19)
+    mime-types (2.4.3)
     multi_json (1.3.7)
+    netrc (0.10.2)
     nokogiri (1.5.5)
     nokogiri-happymapper (0.5.6)
       nokogiri (~> 1.5)
     rake (10.0.2)
     rdoc (3.12)
       json (~> 1.4)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
+    rest-client (1.7.2)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     rspec (2.12.0)
       rspec-core (~> 2.12.0)
       rspec-expectations (~> 2.12.0)
@@ -52,6 +54,6 @@ DEPENDENCIES
   nokogiri (>= 1.5.5)
   nokogiri-happymapper (>= 0.5.4)
   rake
-  rest-client (~> 1.6.0)
+  rest-client (>= 1.7.2)
   rspec
   stale_fish (~> 1.3.2)

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ begin
     gem.homepage = "http://github.com/jsmestad/pivotal-tracker"
     gem.authors = ["Justin Smestad", "Josh Nichols", "Terence Lee"]
 
-    gem.add_dependency 'rest-client', '~> 1.6.0'
+    gem.add_dependency 'rest-client', '>= 1.7.2'
     gem.add_dependency 'happymapper', '>= 0.3.2'
     gem.add_dependency 'builder'
     gem.add_dependency 'nokogiri', '>= 1.4.3'

--- a/pivotal-tracker.gemspec
+++ b/pivotal-tracker.gemspec
@@ -83,12 +83,12 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<rest-client>, ["~> 1.6.0"])
+      s.add_runtime_dependency(%q<rest-client>, [">= 1.7.2"])
       s.add_runtime_dependency(%q<nokogiri-happymapper>, [">= 0.5.4"])
       s.add_runtime_dependency(%q<builder>, [">= 0"])
       s.add_runtime_dependency(%q<nokogiri>, [">= 1.5.5"])
       s.add_runtime_dependency(%q<crack>, [">= 0"])
-      s.add_runtime_dependency(%q<rest-client>, ["~> 1.6.0"])
+      s.add_runtime_dependency(%q<rest-client>, [">= 1.7.2"])
       s.add_runtime_dependency(%q<happymapper>, [">= 0.3.2"])
       s.add_runtime_dependency(%q<builder>, [">= 0"])
       s.add_runtime_dependency(%q<nokogiri>, [">= 1.4.3"])
@@ -97,12 +97,12 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<jeweler>, [">= 0"])
       s.add_development_dependency(%q<stale_fish>, ["~> 1.3.0"])
     else
-      s.add_dependency(%q<rest-client>, ["~> 1.6.0"])
+      s.add_dependency(%q<rest-client>, [">= 1.7.2"])
       s.add_dependency(%q<nokogiri-happymapper>, [">= 0.5.4"])
       s.add_dependency(%q<builder>, [">= 0"])
       s.add_dependency(%q<nokogiri>, [">= 1.5.5"])
       s.add_dependency(%q<crack>, [">= 0"])
-      s.add_dependency(%q<rest-client>, ["~> 1.6.0"])
+      s.add_dependency(%q<rest-client>, [">= 1.7.2"])
       s.add_dependency(%q<happymapper>, [">= 0.3.2"])
       s.add_dependency(%q<builder>, [">= 0"])
       s.add_dependency(%q<nokogiri>, [">= 1.4.3"])
@@ -112,12 +112,12 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<stale_fish>, ["~> 1.3.0"])
     end
   else
-    s.add_dependency(%q<rest-client>, ["~> 1.6.0"])
+    s.add_dependency(%q<rest-client>, [">= 1.7.2"])
     s.add_dependency(%q<nokogiri-happymapper>, [">= 0.5.4"])
     s.add_dependency(%q<builder>, [">= 0"])
     s.add_dependency(%q<nokogiri>, [">= 1.5.5"])
     s.add_dependency(%q<crack>, [">= 0"])
-    s.add_dependency(%q<rest-client>, ["~> 1.6.0"])
+    s.add_dependency(%q<rest-client>, [">= 1.7.2"])
     s.add_dependency(%q<happymapper>, [">= 0.3.2"])
     s.add_dependency(%q<builder>, [">= 0"])
     s.add_dependency(%q<nokogiri>, [">= 1.4.3"])


### PR DESCRIPTION
rest-client 1.6.0 has a nasty habit of trying to use SSLv3 as the preferred cipher even when you specify alternative cipher preferences in your environment. SSLv3 has been removed from many web servers, including Pivotal's. This PR upgrades to a more recent version of rest-client, which fixes SSL negotiation problems when talking to Pivotal's API.
